### PR TITLE
Fix relative path for font

### DIFF
--- a/assets/css/built/styles.css
+++ b/assets/css/built/styles.css
@@ -1503,7 +1503,7 @@ div.pswp__img--placeholder,
   font-display: auto;
   font-style: normal;
   font-named-instance: "Regular";
-  src: url("/fonts/InterVariable.woff2") format("woff2");
+  src: url("../fonts/InterVariable.woff2") format("woff2");
 }
 [x-cloak] {
   display: none !important;

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -12,7 +12,7 @@
   font-display: auto;
   font-style: normal;
   font-named-instance: "Regular";
-  src: url("/fonts/InterVariable.woff2") format("woff2");
+  src: url("fonts/InterVariable.woff2") format("woff2");
 }
 
 [x-cloak] {

--- a/layouts/partials/site_head.html
+++ b/layouts/partials/site_head.html
@@ -10,7 +10,7 @@
   <link rel="icon" type="image/svg+xml" href="{{ "images/favicon.svg" | relURL }}" />
   <link rel="icon" type="image/png" href="{{ "images/favicon.png" | relURL }}" />
   <link rel="apple-touch-icon" sizes="180x180" href="{{ "images/apple-touch-icon.png" | relURL }}" />
-  <link rel="preload" href="/fonts/InterVariable.woff2" as="font" type="font/woff2" crossorigin="anonymous" integrity="sha256-ive9W1RVZ63/s9/Otb7bNTpSLXvxs6K4r3tgZBVrq8A=" />
+  <link rel="preload" href="fonts/InterVariable.woff2" as="font" type="font/woff2" crossorigin="anonymous" integrity="sha256-ive9W1RVZ63/s9/Otb7bNTpSLXvxs6K4r3tgZBVrq8A=" />
   <meta name="description" content="{{ with .Description }}{{ . }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}" />
   {{ hugo.Generator }}
   {{ if .Params.private }}

--- a/layouts/partials/site_head.html
+++ b/layouts/partials/site_head.html
@@ -10,7 +10,7 @@
   <link rel="icon" type="image/svg+xml" href="{{ "images/favicon.svg" | relURL }}" />
   <link rel="icon" type="image/png" href="{{ "images/favicon.png" | relURL }}" />
   <link rel="apple-touch-icon" sizes="180x180" href="{{ "images/apple-touch-icon.png" | relURL }}" />
-  <link rel="preload" href="fonts/InterVariable.woff2" as="font" type="font/woff2" crossorigin="anonymous" integrity="sha256-ive9W1RVZ63/s9/Otb7bNTpSLXvxs6K4r3tgZBVrq8A=" />
+  <link rel="preload" href="{{ "fonts/InterVariable.woff2" | relURL }}" as="font" type="font/woff2" crossorigin="anonymous" integrity="sha256-ive9W1RVZ63/s9/Otb7bNTpSLXvxs6K4r3tgZBVrq8A=" />
   <meta name="description" content="{{ with .Description }}{{ . }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}" />
   {{ hugo.Generator }}
   {{ if .Params.private }}


### PR DESCRIPTION
First of all, thanks for building this theme :)

I noticed some 404 errors when publishing this to a site with a `baseUrl` that isn't the web root (e.g. `https://www.example.org/photos/` instead of `https://photos.example.org/`). There were a few places where the `fonts` folder was assumed to be in the web root, meaning the `InterVariable.woff2` font wasn't loading correctly. I've updated the path to be relative where needed.