### PR TITLE
✨ Added rel option

### DIFF
--- a/layouts/partials/site_footer.html
+++ b/layouts/partials/site_footer.html
@@ -5,7 +5,7 @@
     <ul class="my-2 flex flex-wrap justify-center">
       {{ range .Site.Menus.footer }}
         <li>
-          <a href="{{ .URL }}" class="mx-2">
+          <a rel="{{ .Params.Rel }}" href="{{ .URL }}" class="mx-2">
             {{ .Name }}
           </a>
         </li>


### PR DESCRIPTION
This adds an option to specify rel in the footer of the page.

You need this for example if you want to verify your URL for Mastodon.

I added it in a neutral way.

Usage example: https://github.com/LNA-DEV/Photo/blob/99142e00fdd1c1f9ab277050d784d179096f6094/hugo.yaml#L49C11-L49C11