### PR TITLE
Hide menu button when there's no menu to display

### DIFF
--- a/assets/js/menu.js
+++ b/assets/js/menu.js
@@ -1,12 +1,9 @@
 const el = document.getElementById("menu-toggle");
-el.addEventListener("click", (event) => {
-  event.preventDefault();
-  const target = document.getElementById("menu");
-  if (target.classList.contains("hidden")) {
-    target.classList.remove("hidden");
-    el.ariaExpanded = true;
-  } else {
-    target.classList.add("hidden");
-    el.ariaExpanded = false;
-  }
-});
+if (el) {
+  el.addEventListener("click", (event) => {
+    event.preventDefault();
+    const target = document.getElementById("menu");
+    el.ariaExpanded = target.classList.contains("hidden");
+    target.classList.toggle("hidden");
+  });
+}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -10,6 +10,7 @@
       {{ .Site.Title }}
     </a>
   {{ end }}
+  {{ if (gt site.Menus.main.Len 0) }}
   <ul>
     <li>
       <button class="btn btn-square group" id="menu-toggle" aria-expanded="false" type="button" title="{{ T "menu" }}">
@@ -22,5 +23,6 @@
       </button>
     </li>
   </ul>
+  {{ end }}
 </header>
 {{ partial "menu.html" . }}

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -1,3 +1,4 @@
+{{ if (gt site.Menus.main.Len 0) }}
 <menu class="hidden" id="menu">
   {{ range site.Menus.main }}
     <li itemscope itemtype="http://www.schema.org/SiteNavigationElement">
@@ -7,3 +8,4 @@
     </li>
   {{ end }}
 </menu>
+{{ end }}


### PR DESCRIPTION
Currently, the menu button is shown even if we don't set any menu entry. This hides the button in such cases.