### PR TITLE
feat: Create ja.yaml

### DIFF
--- a/i18n/da.yaml
+++ b/i18n/da.yaml
@@ -1,13 +1,6 @@
-albumCount:
-  one: 1 album
-  other: "{{ . }} albummer"
 menu: Menu
-in: i
 home: Hjem
 pageNotFound: Siden blev ikke fundet
-photoCount:
-  one: 1 billede
-  other: "{{ . }} billeder"
 toHomepage: Til forsiden
 closeTitle: Luk
 zoomTitle: Zoom
@@ -16,3 +9,9 @@ arrowNextTitle: Næste
 errorMsg: Billedet kunne ikke indlæses
 downloadTitle: Download
 relatedAlbums: Lignende albums
+photoCount:
+  one: 1 billede
+  other: "{{ . }} billeder"
+albumCount:
+  one: "{{ .photoCount }} i {{ .count }} album"
+  other: "{{ .photoCount }} i {{ .count }} albummer"

--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -1,13 +1,6 @@
-albumCount:
-  one: 1 Album
-  other: "{{ . }} Alben"
 menu: Menü
-in: in
 home: Home
 pageNotFound: Seite nicht gefunden
-photoCount:
-  one: 1 Foto
-  other: "{{ . }} Fotos"
 toHomepage: Zur Startseite
 closeTitle: Schließen
 zoomTitle: Vergrößern
@@ -16,3 +9,9 @@ arrowNextTitle: Weiter
 errorMsg: Das Bild konnte nicht geladen werden
 downloadTitle: Download
 relatedAlbums: Ähnliche Alben
+photoCount:
+  one: 1 Foto
+  other: "{{ . }} Fotos"
+albumCount:
+  one: "{{ .photoCount }} in {{ .count }} Album"
+  other: "{{ .photoCount }} in {{ .count }} Alben"

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -1,13 +1,6 @@
-albumCount:
-  one: 1 album
-  other: "{{ . }} albums"
 menu: Menu
-in: in
 home: Home
 pageNotFound: Page not found
-photoCount:
-  one: 1 photo
-  other: "{{ . }} photos"
 toHomepage: Go to homepage
 closeTitle: Close
 zoomTitle: Zoom
@@ -16,3 +9,9 @@ arrowNextTitle: Next
 errorMsg: The photo cannot be loaded
 downloadTitle: Download
 relatedAlbums: Related albums
+photoCount:
+  one: 1 photo
+  other: "{{ . }} photos"
+albumCount:
+  one: "{{ .photoCount }} in {{ .count }} album"
+  other: "{{ .photoCount }} in {{ .count }} albums"

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -1,13 +1,6 @@
-albumCount:
-  one: 1 album
-  other: "{{ . }} albums"
 menu: Menu
-in: dans
 home: Accueil
 pageNotFound: Page non trouvée
-photoCount:
-  one: 1 photo
-  other: "{{ . }} photos"
 toHomepage: Aller à l'accueil
 closeTitle: Fermer
 zoomTitle: Zoom
@@ -16,3 +9,9 @@ arrowNextTitle: Suivant
 errorMsg: L'image n'a pas pu être chargée
 downloadTitle: Télécharger
 relatedAlbums: Albums similaires
+photoCount:
+  one: 1 photo
+  other: "{{ . }} photos"
+albumCount:
+  one: "{{ .photoCount }} dans {{ .count }} album"
+  other: "{{ .photoCount }} dans {{ .count }} albums"

--- a/i18n/it.yaml
+++ b/i18n/it.yaml
@@ -1,13 +1,6 @@
-albumCount:
-  one: 1 album
-  other: "{{ . }} album"
 menu: Menu
-in: in
 home: Home
 pageNotFound: Pagina non trovata
-photoCount:
-  one: 1 foto
-  other: "{{ . }} foto"
 toHomepage: Vai alla home
 closeTitle: Chiudi
 zoomTitle: Zoom
@@ -16,3 +9,9 @@ arrowNextTitle: Avanti
 errorMsg: La foto non può essere scaricata
 downloadTitle: Download
 relatedAlbums: Album correlati
+photoCount:
+  one: 1 foto
+  other: "{{ . }} foto"
+albumCount:
+  one: "{{ .photoCount }} in {{ .count }} album"
+  other: "{{ .photoCount }} in {{ .count }} album"

--- a/i18n/ja.yaml
+++ b/i18n/ja.yaml
@@ -1,0 +1,15 @@
+menu: メニュー
+home: ホーム
+pageNotFound: ページが見つかりません
+toHomepage: ホームに戻る 
+closeTitle: 閉める
+zoomTitle: ズーム
+arrowPrevTitle: 前
+arrowNextTitle: 次
+errorMsg: 写真を読み込めませんでした
+downloadTitle: ダウンロード
+relatedAlbums: 似たようなアルバム
+photoCount:
+  other: "写真{{ . }}枚"
+albumCount:
+  other: "{{ .count }}枚のアルバムに{{ .photoCount }}"

--- a/i18n/zh.yaml
+++ b/i18n/zh.yaml
@@ -1,13 +1,6 @@
-albumCount:
-  one: 1 个相册
-  other: "{{ . }} 个相册"
 menu: 菜单
-in: 在
 home: 主页
 pageNotFound: 页面不存在
-photoCount:
-  one: 1 张照片
-  other: "{{ . }} 张照片"
 toHomepage: 返回主页
 closeTitle: 关闭
 zoomTitle: 缩放
@@ -16,3 +9,7 @@ arrowNextTitle: 后一张
 errorMsg: 照片无法加载
 downloadTitle: 下载
 relatedAlbums: 相关相册
+photoCount:
+  other: "{{ . }} 张照片"
+albumCount:
+  other: "{{ .photoCount }} 在 {{ .count }} 个相册"

--- a/layouts/partials/album-card.html
+++ b/layouts/partials/album-card.html
@@ -6,9 +6,9 @@
       <h2>{{ .page.Title }}</h2>
       <p>
         {{ if gt .albumCount 0 }}
-          {{ T "albumCount" (dict "count" .albumCount "photoCount" (.imageCount | lang.Translate "photoCount")) }}
+          {{ T "albumCount" (dict "count" (.albumCount | lang.FormatNumber 0) "photoCount" (.imageCount | lang.FormatNumber 0 | lang.Translate "photoCount")) }}
         {{ else }}
-          {{ T "photoCount" .imageCount }}
+          {{ T "photoCount" (.imageCount | lang.FormatNumber 0) }}
         {{ end }}
       </p>
     </div>

--- a/layouts/partials/album-card.html
+++ b/layouts/partials/album-card.html
@@ -5,8 +5,11 @@
     <div>
       <h2>{{ .page.Title }}</h2>
       <p>
-        {{ T "photoCount" (.imageCount | lang.FormatNumber 0) }}
-        {{ if gt .albumCount 0 }}{{ T "in" }} {{ T "albumCount" (.albumCount | lang.FormatNumber 0) }}{{ end }}
+        {{ if gt .albumCount 0 }}
+          {{ T "albumCount" (dict "count" .albumCount "photoCount" (.imageCount | lang.Translate "photoCount")) }}
+        {{ else }}
+          {{ T "photoCount" .imageCount }}
+        {{ end }}
       </p>
     </div>
   </a>

--- a/layouts/partials/featured.html
+++ b/layouts/partials/featured.html
@@ -11,9 +11,9 @@
           <h2>{{ .Title }}</h2>
           <p>
             {{ if gt $gallery.albumCount 0 }}
-              {{ T "albumCount" (dict "count" $gallery.albumCount "photoCount" ($gallery.imageCount | lang.Translate "photoCount")) }}
+              {{ T "albumCount" (dict "count" ($gallery.albumCount | lang.FormatNumber 0) "photoCount" ($gallery.imageCount | lang.FormatNumber 0 | lang.Translate "photoCount")) }}
             {{ else }}
-              {{ T "photoCount" $gallery.imageCount }}
+              {{ T "photoCount" ($gallery.imageCount | lang.FormatNumber 0) }}
             {{ end }}
           </p>
         </div>

--- a/layouts/partials/featured.html
+++ b/layouts/partials/featured.html
@@ -10,8 +10,11 @@
         <div>
           <h2>{{ .Title }}</h2>
           <p>
-            {{ T "photoCount" ($gallery.imageCount | lang.FormatNumber 0) }}
-            {{ if gt $gallery.albumCount 0 }}{{ T "in" }} {{ T "albumCount" ($gallery.albumCount | lang.FormatNumber 0) }}{{ end }}
+            {{ if gt $gallery.albumCount 0 }}
+              {{ T "albumCount" (dict "count" $gallery.albumCount "photoCount" ($gallery.imageCount | lang.Translate "photoCount")) }}
+            {{ else }}
+              {{ T "photoCount" $gallery.imageCount }}
+            {{ end }}
           </p>
         </div>
       </a>


### PR DESCRIPTION
Adding Japanese support required to change how the "X photos in Y albums" sentence was handled, as Japanese doesn't say it the same way. Let me know if you feel like there's a better way to handle this !

I also took the opportunity to remove `lang.FormatNumber` as we only ever get integers, and their formatting is language independent.