### PR TITLE
Allow extra content

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -2,4 +2,9 @@
   {{ partial "title.html" . }}
   {{ partial "gallery.html" . }}
   {{ partial "related.html" . }}
+  {{ with .Content }}
+  <section class="prose">
+    {{ . }}
+  </section>
+  {{ end }}
 {{ end }}


### PR DESCRIPTION
In addition to configuring the content of a gallery through frontmatter on its own, here is the option to add additional content below the gallery.

In my case, I'd like to be able to add a Vimeo video that is related to this particular gallery.