### PR TITLE
Enable markdown in description

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ content/
 
 - `title` -- title of the album, shown in the album list and on the album page.
 - `date` -- album date, used for sorting (newest first).
-- `description` -- description shown on the album page.
+- `description` -- description shown on the album page. Rendered as markdown to enable adding links and some formatting.
 - `featured_image` -- name of the image file used for the album thumbnail. If not set, the first image which contains `feature` in its filename is used, otherwise the first image in the album.
 - `weight` -- can be used to adjust sort order.
 - `private` -- if set to `true`, this album is not shown in the album overview and is excluded from RSS feeds.

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -6,7 +6,7 @@
   <link rel="icon" type="image/svg+xml" href="{{ "images/favicon.svg" | relURL }}" />
   <link rel="icon" type="image/png" href="{{ "images/favicon.png" | relURL }}" />
   <link rel="apple-touch-icon" sizes="180x180" href="{{ "images/apple-touch-icon.png" | relURL }}" />
-  <meta name="description" content="{{ with .Description }}{{ . }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}" />
+  <meta name="description" content="{{ with .Description }}{{ . | markdownify | plainify }}{{ else }}{{ with .Site.Params.description }}{{ . | markdownify | plainify }}{{ end }}{{ end }}" />
   {{ if .Params.keywords }}
     <meta name="keywords" content="{{ delimit .Params.keywords `, ` }}" />
   {{ end }}

--- a/layouts/partials/opengraph.html
+++ b/layouts/partials/opengraph.html
@@ -1,5 +1,5 @@
 <meta property="og:title" content="{{ if .IsHome }}{{ with .Site.Params.title }}{{ . }}{{ end }}{{ else }}{{ .Title }}{{ end }}" />
-<meta property="og:description" content="{{ with .Description }}{{ . }}{{ else }}{{ if .IsPage }}{{ .Summary }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end }}" />
+<meta property="og:description" content="{{ with .Description }}{{ . | markdownify | plainify }}{{ else }}{{ if .IsPage }}{{ .Summary }}{{ else }}{{ with .Site.Params.description }}{{ . | markdownify | plainify }}{{ end }}{{ end }}{{ end }}" />
 <meta property="og:type" content="{{ if .IsPage }}article{{ else }}website{{ end }}" />
 <meta property="og:url" content="{{ .Permalink }}" />
 

--- a/layouts/partials/title.html
+++ b/layouts/partials/title.html
@@ -2,7 +2,7 @@
   <hgroup>
     <h1>{{ .Title }}</h1>
     {{ with .Params.Description }}
-      <p>{{ . }}</p>
+      <p>{{ . | markdownify }}</p>
     {{ end }}
   </hgroup>
 {{ end }}


### PR DESCRIPTION
I had the desire to put a link into the description. Was happy to discover that enabling markdown use in description was very simple to enable.

I hope that does not break anything I'm unaware of. Tried to strip the formatting in the fields where it's not desirable.

Tested with links, lists, headings, `code`, all looked fine and did not break the site with the default layout as far as I could see.