### PR TITLE
feat: added capability to randomize the album covers

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ content/
 - `description` -- description shown on the album page. Rendered as markdown to enable adding links and some formatting.
 - `weight` -- can be used to adjust sort order.
 - `params.featured_image` -- name of the image file used for the album thumbnail. If not set, the first image which contains `feature` in its filename is used, otherwise the first image in the album.
+- `params.random_featured` -- if set to `true`, this will select a random image from the album amongst the eligible images (See [Random Album Cover](#random-album-cover) for more details). 
 - `params.private` -- if set to `true`, this album is not shown in the album overview and is excluded from RSS feeds.
 - `params.featured` -- if set to `true`, this album is featured on the homepage (even if private).
 - `params.sort_by` -- property used for sorting images in an album. Default is `Name` (filename), but can also be `Date`.
@@ -106,6 +107,20 @@ resources:
   - src: tree.jpg
     params:
       cover: true
+---
+```
+#### Random Album Cover
+If `random_featured` is enabled for an album, its cover will be, by order of priority: 
+1.  the `featured_image`
+2.  A random image from the images with `feature` in its filename
+3.  A random image from images with the parameter `cover` set to `true`
+4.  A random image from the album
+
+The parameter can be set in the root cover with `Cascade` to apply to all albums (set to `false` on a specific album to disable for that album, or `cascade/false` to disable also for the subalbums)
+```plain
+---
+cascade:
+  random_featured: true
 ---
 ```
 

--- a/layouts/partials/_get_featured_image.html
+++ b/layouts/partials/_get_featured_image.html
@@ -1,0 +1,28 @@
+{{ $images := .images }}
+{{ $params := .params }}
+
+{{ $selectedImages := slice }}
+{{ if $params.featured_image }}
+    {{ with $images.GetMatch $params.featured_image }}
+        {{ $selectedImages = $selectedImages | append . }}
+    {{ end }}
+{{ end }}
+{{ if eq (len $selectedImages) 0 }}
+    {{ range $images }}
+        {{ if strings.Contains (lower .Name) "feature" }}
+            {{ $selectedImages = $selectedImages | append . }}
+        {{ end }}
+    {{ end }}
+{{ end }}
+{{ if eq (len $selectedImages) 0 }}
+    {{ range $images }}
+        {{ if index .Params "cover" }}
+            {{ $selectedImages = $selectedImages | append . }}
+        {{ end }}
+    {{ end }}
+{{ end }}
+{{ $selectedImages = cond (eq (len $selectedImages) 0) $images $selectedImages }}
+{{ $featuredImage := cond ($params.random_featured)
+  ( index ($selectedImages | shuffle) 0 )
+  ( index $selectedImages 0 ) }}
+{{ return $featuredImage }}

--- a/layouts/partials/featured.html
+++ b/layouts/partials/featured.html
@@ -2,14 +2,8 @@
   {{ $gallery := partial "get-gallery.html" . }}
   {{ if $gallery }}
     {{ $images := .Resources.ByType "image" }}
-    {{ $index := 0 }}
-    {{ range $i, $image := $images }}
-      {{ if index $image.Params "cover" }}
-        {{ $index = $i }}
-      {{ end }}
-    {{ end }}
-    {{ $featured := ($images.GetMatch (.Params.featured_image | default "*feature*")) | default (index $images $index) }}
-    {{ $thumbnail := $featured.Filter (slice images.AutoOrient (images.Process "fit 1600x1600")) }}
+    {{ $featuredImage := partial "_get_featured_image" (dict "images" $images "params" .Params) }}
+    {{ $thumbnail := $featuredImage.Filter (slice images.AutoOrient (images.Process "fit 1600x1600")) }}
     {{ $color := index $thumbnail.Colors 0 | default "transparent" }}
     <section class="featured">
       <a class="featured-card" href="{{ .RelPermalink }}" style="background-color: {{ $color }}; background-image: url({{ $thumbnail.RelPermalink }})">

--- a/layouts/partials/get-gallery.html
+++ b/layouts/partials/get-gallery.html
@@ -1,15 +1,9 @@
 {{ $gallery := "" }}
 {{ $images := .Resources.ByType "image" }}
 {{ if gt (len $images) 0 }}
-  {{ $index := 0 }}
-  {{ range $i, $image := $images }}
-    {{ if index $image.Params "cover" }}
-      {{ $index = $i }}
-    {{ end }}
-  {{ end }}
-  {{ $featured := ($images.GetMatch (.Params.featured_image | default "*feature*")) | default (index $images $index) }}
-  {{ $thumbnail := $featured.Filter (slice images.AutoOrient (images.Process "fit 600x600")) }}
-  {{ $color := index $thumbnail.Colors 0 | default "transparent" }}
+  {{ $featuredImage := partial "_get_featured_image" (dict "images" $images "params" .Params) }}
+  {{ $thumbnail := $featuredImage.Filter (slice images.AutoOrient (images.Process "fit 600x600")) }}
+  {{ $color := index $thumbnail.Colors 0 | default "transparent" }} 
   {{ $imageCount := 0 }}
   {{ $albumCount := 0 }}
   {{ if .IsPage }}

--- a/layouts/partials/opengraph.html
+++ b/layouts/partials/opengraph.html
@@ -33,14 +33,12 @@
 {{- end }}
 
 {{- $images := $.Resources.ByType "image" -}}
-{{ $index := 0 }}
-{{ range $i, $image := $images }}
-  {{ if index $image.Params "cover" }}
-    {{ $index = $i }}
-  {{ end }}
-{{ end }}
-{{ $image := ($images.GetMatch (.Params.featured_image | default "*feature*")) | default (index $images $index) }}
-{{- with $image -}}
-  {{ $full := $image.Filter (slice images.AutoOrient (images.Process "fit 1600x1600")) }}
-  <meta property="og:image" content="{{ $full.Permalink }}" />
+{{ if gt (len $images) 0 }}
+  {{ $featuredImage := partial "_get_featured_image" (dict "images" $images  "params" .Params) }}
+  {{- with $featuredImage -}}
+    {{ $full := .Filter (slice images.AutoOrient (images.Process "fit 1200x1200")) }}
+    <meta property="og:image" content="{{ $full.Permalink }}" />
+    <meta property="og:image:width" content="{{ $full.Width }}" />
+    <meta property="og:image:height" content="{{ $full.Height }}" />
+  {{- end -}}
 {{- end -}}


### PR DESCRIPTION
- Modularized image selection logic by moving it to a dedicated partial `_get_featured_image.html` (used by get_gallery, featured and opengraph
- Improved image selection logic with prioritized fallback and returning list:
  1. First tries to match specified `featured_image` parameter
  3. Then looks for images with "feature" in their filename
  4. Finally searches  for images with `cover` parameter in their front matter
  5. If no matches found, uses all available images
- Added new `random_featured` parameter to optionally pick a random image from this list at build time
- new subsection in the readme to explain
You may want to fix the calls to partials with .html and the new partial name if this doesn't fit your schema. 

