### PR TITLE
feat: hidden images

### DIFF
--- a/exampleSite/content/featured-album/index.md
+++ b/exampleSite/content/featured-album/index.md
@@ -4,6 +4,8 @@ title: Featured Album
 params:
   featured: true
   private: true # do not show in list, only as feature
+  hidden_images:
+    - this-wont-be-show-in-the-gallery.png
 description: This is a featured album. It is private, so it is only shown on the homepage.
 resources:
   - src: jeremy-bishop-pjszS6Q2g_Y-unsplash.jpg

--- a/layouts/partials/gallery.html
+++ b/layouts/partials/gallery.html
@@ -1,6 +1,7 @@
 <section class="gallery">
   <div id="gallery" style="visibility: hidden; height: 1px; overflow: hidden">
     {{ $images := slice }}
+    {{ $hiddenImages := .Params.hidden_images | default (slice) }}
     {{ range $image := .Resources.ByType "image" }}
       {{ $title := "" }}
       {{ $date := "" }}
@@ -19,14 +20,17 @@
         {{/* Date from front matter */}}
         {{ $date = time $image.Params.Date }}
       {{ end }}
-      {{ $images = $images | append (dict
-        "Name" $image.Name
-        "Title" $title
-        "Date" $date
-        "image" $image
-        "Params" $image.Params
-        )
-      }}
+      {{ if in $hiddenImages $image.Name }}
+        <!-- This image is hidden: {{ $image.Name }} -->
+      {{ else }}
+        {{ $images = $images | append (dict
+          "Name" $image.Name
+          "Title" $title
+          "Date" $date
+          "image" $image
+          "Params" $image.Params
+        ) }}
+      {{ end }}
     {{ end }}
     {{ $publishResources := default true .Params.build.publishResources }}
     {{ range sort $images (.Params.sort_by | default "Name") (.Params.sort_order | default "asc") }}


### PR DESCRIPTION
I wanted to show an image on the featured-album card that I didn't want rendered in the image list. So I modified the gallery.html to check the front matter of the index.md to look for images defined in:

```markdown
---
date: 2023-01-12
featured_image: only-for-album-card-not-list.png
title: Featured Album
params:
    featured: true
    private: true
    hidden_images:
      - only-for-album-card-not-list.png
---

```