### PR TITLE
Add spoiler feature, show the spoiler content on the image and as an image tooltip

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A very simple and opinionated photo gallery theme for Hugo.
 - Lightbox with [PhotoSwipe](https://photoswipe.com/)
 - SEO with Open Graph tags
 - Automatic (or manual) selection of feature/cover images
+- "Spoiler" images with content warnings (CW)
 
 **Important note: do not try to use WebP images.** The golang WebP implementation used in Hugo has a bug which leads to wrong image levels (dull looking images) upon resize. See [nicokaiser/hugo-theme-gallery#102](https://github.com/nicokaiser/hugo-theme-gallery/issues/102) for more details.
 
@@ -93,6 +94,7 @@ content/
 - `params.featured` -- if set to `true`, this album is featured on the homepage (even if private).
 - `params.sort_by` -- property used for sorting images in an album. Default is `Name` (filename), but can also be `Date`.
 - `params.sort_order` -- sort order. Default is `asc`.
+- `params.spoiler` -- if set to a string value, this image's thumbnail will be blurred, darkened, and the text will be put on top of it. Main image isn't modified.
 - `params.theme` -- color theme for this page. Defaults to `defaultTheme` from configuration.
 
 ### Album Cover

--- a/layouts/partials/gallery.html
+++ b/layouts/partials/gallery.html
@@ -32,11 +32,23 @@
     {{ range sort $images (.Params.sort_by | default "Name") (.Params.sort_order | default "asc") }}
       {{ $image := .image }}
       {{ $thumbnail := $image.Filter (slice images.AutoOrient (images.Process "fit 600x600")) }}
+      {{ if .Params.spoiler }}
+        {{ $spoilerTextOpts := dict
+            "color" "#fbfaf5"
+            "linespacing" 0
+            "size" 40
+            "x" (mul $thumbnail.Width 0.5 | int)
+            "y" (mul $thumbnail.Height 0.5 | int)
+            "alignx" "center"
+            "aligny" "center"
+        }}
+        {{ $thumbnail = $thumbnail.Filter (slice (images.GaussianBlur 30 ) (images.Brightness -20) ( images.Text .Params.spoiler $spoilerTextOpts ))}}
+      {{ end }}
       {{ $full := $image.Filter (slice images.AutoOrient (images.Process "fit 1600x1600")) }}
       {{ $color := index $thumbnail.Colors 0 | default "transparent" }}
       <a class="gallery-item" href="{{ if $publishResources }}{{ $image.RelPermalink }}{{ else }}{{ $full.RelPermalink }}{{ end }}" data-pswp-src="{{ $full.RelPermalink }}" data-pswp-width="{{ $full.Width }}" data-pswp-height="{{ $full.Height }}" data-pswp-target="{{ $image.Name | urlize }}" title="{{ .Title }}" itemscope itemtype="https://schema.org/ImageObject" style="aspect-ratio: {{ $thumbnail.Width }} / {{ $thumbnail.Height }}">
         <figure style="background-color: {{ $color }}; aspect-ratio: {{ $thumbnail.Width }} / {{ $thumbnail.Height }}">
-          <img class="lazyload" width="{{ $thumbnail.Width }}" height="{{ $thumbnail.Height }}" data-src="{{ $thumbnail.RelPermalink }}" alt="{{ .Title }}" />
+          <img class="lazyload" width="{{ $thumbnail.Width }}" height="{{ $thumbnail.Height }}" data-src="{{ $thumbnail.RelPermalink }}" alt="{{ .Title }}" title="{{ .Params.spoiler }}" />
         </figure>
         <meta itemprop="contentUrl" content="{{ if $publishResources }}{{ $image.RelPermalink }}{{ else }}{{ $full.RelPermalink }}{{ end }}" />
         {{ with site.Params.Author }}


### PR DESCRIPTION
This MR:
- Adds a new parameter for images: `spoiler`
  - If this value is set, the image thumbnail in the gallery will be blurred
  - The content of the parameter will be put on top of the thumbnail
  - It will also be put as the image `title` field (the tooltip)
  - Documented in README

Note that some parameters I use (the `alignx`/`aligny` parameters were introduced respectively in Hugo v0.141.0/v0.147.0 .
However, this MR works perfectly fine on Hugo v0.131.0, even if the texts are off-centered.