### PR TITLE
updated gallery.html to contain exif metadata in a panel

### DIFF
--- a/layouts/partials/gallery.html
+++ b/layouts/partials/gallery.html
@@ -38,7 +38,25 @@
         <figure style="background-color: {{ $color }}; aspect-ratio: {{ $thumbnail.Width }} / {{ $thumbnail.Height }}">
           <img class="lazyload" width="{{ $thumbnail.Width }}" height="{{ $thumbnail.Height }}" data-src="{{ $thumbnail.RelPermalink }}" alt="{{ .Title }}" />
         </figure>
-        <meta itemprop="contentUrl" content="{{ if $publishResources }}{{ $image.RelPermalink }}{{ else }}{{ $full.RelPermalink }}{{ end }}" />
+          {{ if $image.Exif }}
+            <span class="pswp-caption-content">
+              {{ with .Title }}{{ . }}<br />{{ end }}
+              <span class="pswp-caption-content-date">
+                {{ with .Date}}{{ . | time.Format ":date_full" }}<br />{{ end }}
+              </span>
+              <span class="pswp-caption-content-exif">
+                {{ with $image.Exif.Tags }}
+                  {{ if .Model }}
+                    {{ .Make }} {{ .Model }}<br />
+                  {{ end }}
+              </span>
+              <span class="pswp-caption-content-exif">{{ with .FocalLength }}{{ . }}mm &emsp14;&middot;&emsp14; {{ end }}</span>
+              <span class="pswp-caption-content-exif">{{ with .FNumber }}f/{{ div (math.Round (mul (float .) 10)) 10 }} &emsp14;&middot;&emsp14; {{ end }}</span>
+              <span class="pswp-caption-content-exif">{{ with .ExposureTime }}{{ . }}s &emsp14;&middot;&emsp14; {{ end }}</span>
+              <span class="pswp-caption-content-exif">{{ with .ISO }}ISO {{ . }}{{ end }}</span>
+            {{ end }}
+          {{ end }}
+        <meta itemprop="contentUrl" content="{{ $image.RelPermalink }}" />
         {{ with site.Params.Author }}
           <span itemprop="creator" itemtype="https://schema.org/Person" itemscope>
             <meta itemprop="name" content="{{ site.Params.Author.name }}" />


### PR DESCRIPTION
Basic amendment to add broader EXIF metadata into the gallery html - there may be some contention between ApertureValue and FNumber

This broadly follows the code recommended in this issue: https://github.com/nicokaiser/hugo-theme-gallery/issues/77

Have also added some custom css for the 2 new CSS classes introduced:

.pswp-caption-content-date {
    font-size: small;
    color: var(--text-2);
}

.pswp-caption-content-exif {
    font-size: x-small;
    font-style: italic;
    color: var(--text-2);
}

