### PR TITLE
Fix typo

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -18,14 +18,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.124.0
+      HUGO_VERSION: 0.123.0
     steps:
       - name: Install Hugo
         run: |
           wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
           && sudo dpkg -i ${{ runner.temp }}/hugo.deb
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Cache example images
         id: cache-images
         uses: actions/cache@v4
@@ -38,7 +38,7 @@ jobs:
         run: ./pull-images.sh
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v5
       - name: Build with Hugo
         working-directory: ./exampleSite
         env:
@@ -46,7 +46,7 @@ jobs:
           HUGO_ENV: production
         run: hugo --gc --minify --baseURL "${{ steps.pages.outputs.base_url }}/"
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: ./exampleSite/public
 

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ You can also use other taxonomies like `series`. Note that only `categories` and
 
 ### Featured Content on the Homepage
 
-Albums (and als taxonomy pages like categories) can be marked as "featured":
+Albums (and also taxonomy pages like categories) can be marked as "featured":
 
 ```plain
 ---


### PR DESCRIPTION
This PR fixes a typo in `README.md`.
It also bumps GitHub action workflows to their latest versions.