### PR TITLE
Added options to change the resolution for preview and full image

### DIFF
--- a/exampleSite/config/_default/hugo.toml
+++ b/exampleSite/config/_default/hugo.toml
@@ -28,6 +28,8 @@ title = "Gallery"
     #500px = "https://500px"
     #whatsapp = "1234567890"
   [params.gallery]
+    #previewImageSize = "fit 600x600"
+    #fullImageSize = "fit 1600x1600"
     #boxSpacing = 10
     #targetRowHeight = 288
     #targetRowHeightTolerance = 0.25

--- a/layouts/partials/gallery.html
+++ b/layouts/partials/gallery.html
@@ -1,6 +1,8 @@
 <section class="gallery">
   <div id="gallery" style="visibility: hidden; height: 1px; overflow: hidden">
     {{ $images := slice }}
+    {{ $previewProcess := default "fit 600x600" site.Params.gallery.previewImageSize }}
+    {{ $fullProcess := default "fit 1600x1600" site.Params.gallery.fullImageSize }}
     {{ range $image := where (.Resources.ByType "image") "Params.hidden" "ne" true }}
       {{ $title := "" }}
       {{ $date := "" }}
@@ -31,8 +33,8 @@
     {{ $publishResources := default true .Params.build.publishResources }}
     {{ range sort $images (.Params.sort_by | default "Name") (.Params.sort_order | default "asc") }}
       {{ $image := .image }}
-      {{ $thumbnail := $image.Filter (slice images.AutoOrient (images.Process "fit 600x600")) }}
-      {{ $full := $image.Filter (slice images.AutoOrient (images.Process "fit 1600x1600")) }}
+      {{ $thumbnail := $image.Filter (slice images.AutoOrient (images.Process $previewProcess)) }}
+      {{ $full := $image.Filter (slice images.AutoOrient (images.Process $fullProcess)) }}
       {{ $color := index $thumbnail.Colors 0 | default "transparent" }}
       <a class="gallery-item" href="{{ if $publishResources }}{{ $image.RelPermalink }}{{ else }}{{ $full.RelPermalink }}{{ end }}" data-pswp-src="{{ $full.RelPermalink }}" data-pswp-width="{{ $full.Width }}" data-pswp-height="{{ $full.Height }}" data-pswp-target="{{ $image.Name | urlize }}" title="{{ .Title }}" itemscope itemtype="https://schema.org/ImageObject" style="aspect-ratio: {{ $thumbnail.Width }} / {{ $thumbnail.Height }}">
         <figure style="background-color: {{ $color }}; aspect-ratio: {{ $thumbnail.Width }} / {{ $thumbnail.Height }}">


### PR DESCRIPTION
Hi!
It would be convenient to add the ability to specify sizes for the preview and full image.
For greater flexibility, the fit parameter has also been added.

I’ve added examples of how to use the parameter in hugo.toml.

By default, the same parameter values as currently defined in the theme are used.