### PR TITLE
fix: replace deprecated Image.Exif with Image.Meta (Hugo v0.155+)

### DIFF
--- a/layouts/partials/gallery.html
+++ b/layouts/partials/gallery.html
@@ -4,9 +4,9 @@
     {{ range $image := where (.Resources.ByType "image") "Params.hidden" "ne" true }}
       {{ $title := "" }}
       {{ $date := "" }}
-      {{ with $image.Exif }}
+      {{ with $image.Meta }}
         {{ $date = .Date }}
-        {{ with .Tags.ImageDescription }}
+        {{ with .Exif.ImageDescription }}
           {{/* Title from EXIF ImageDescription */}}
           {{ $title = . }}
         {{ end }}


### PR DESCRIPTION
uses `Image.Meta` instead of `Image.Exif`, and `.Exif.ImageDescription` instead of `.Tags.ImageDescription` (the Tags wrapper was removed in the new API).

refs #151
https://gohugo.io/methods/resource/meta/

---

p.s. same as #155 — no rush, just here for whenever.